### PR TITLE
Activate another tab if is Notification page is open.

### DIFF
--- a/extension/lib/main.js
+++ b/extension/lib/main.js
@@ -34,17 +34,17 @@ let tbb = ActionButton({
 	},
 	onClick: function (state) {
 		let found = false;
-		const tab = tabs.activeTab;
-		for (let otherTab of tabs) {
-			if (found = (otherTab.url === notifUrl && otherTab.window == tab.window)) {
-				otherTab.activate();
-				otherTab.reload();
+		const currentTab = tabs.activeTab;
+		for (let tab of tabs) {
+			if (found = (tab.url === notifUrl && tab.window == currentTab.window)) {
+				tab.activate();
+				tab.reload();
 				break;
 			}
 		}
 		if (!found) {
-			if (tab.url === 'about:blank' || tab.url === 'about:newtab' || tab.url === notifUrl) {
-				tab.url = notifUrl;
+			if (currentTab.url === 'about:blank' || currentTab.url === 'about:newtab') {
+				currentTab.url = notifUrl;
 			} else {
 				tabs.open(notifUrl);
 			}

--- a/extension/lib/main.js
+++ b/extension/lib/main.js
@@ -36,7 +36,7 @@ let tbb = ActionButton({
 		let found = false;
 		const currentTab = tabs.activeTab;
 		for (let tab of tabs) {
-			if (found = (tab.url === notifUrl && tab.window == currentTab.window)) {
+			if (found = (tab.url === notifUrl && tab.window === currentTab.window)) {
 				tab.activate();
 				tab.reload();
 				break;

--- a/extension/lib/main.js
+++ b/extension/lib/main.js
@@ -34,14 +34,21 @@ let tbb = ActionButton({
 	},
 	onClick: function (state) {
 		let found = false;
+		const tab = tabs.activeTab;
 		for (let otherTab of tabs) {
-			if (found = otherTab.url === notifUrl) {
+			if (found = (otherTab.url === notifUrl && otherTab.window == tab.window)) {
 				otherTab.activate();
 				otherTab.reload();
 				break;
 			}
 		}
-		found || tabs.open(notifUrl);
+		if (!found) {
+			if (tab.url === 'about:blank' || tab.url === 'about:newtab' || tab.url === notifUrl) {
+				tab.url = notifUrl;
+			} else {
+				tabs.open(notifUrl);
+			}
+		}
 
 		timers.setTimeout(update, 1000 * 20);
 		update();

--- a/extension/lib/main.js
+++ b/extension/lib/main.js
@@ -33,13 +33,15 @@ let tbb = ActionButton({
 		'64': './icon-64.png',
 	},
 	onClick: function (state) {
-		const tab = tabs.activeTab;
-
-		if (tab.url === 'about:blank' || tab.url === 'about:newtab' || tab.url === notifUrl) {
-			tab.url = notifUrl;
-		} else {
-			tabs.open(notifUrl);
+		let found = false;
+		for (let otherTab of tabs) {
+			if (found = otherTab.url === notifUrl) {
+				otherTab.activate();
+				otherTab.reload();
+				break;
+			}
 		}
+		found || tabs.open(notifUrl);
 
 		timers.setTimeout(update, 1000 * 20);
 		update();


### PR DESCRIPTION
Hi! I've added a small check to all open tabs to eventually activate the first one found. Let me know if you find this useful.

Not only check if current tab is the notification panel, but also check if any other tab is the `notifUrl`, and eventually `.activate()` and `.reload()` it.